### PR TITLE
Cleanup includes and harmonize member variable names

### DIFF
--- a/k4MLJetTagger/src/components/Helpers.cpp
+++ b/k4MLJetTagger/src/components/Helpers.cpp
@@ -18,8 +18,6 @@
  */
 #include "Helpers.h"
 
-#include "Gaudi/Property.h"
-
 #include <DD4hep/DD4hepUnits.h>
 
 double getBzAtOrigin(dd4hep::Detector* theDetector) {

--- a/k4MLJetTagger/src/components/Helpers.cpp
+++ b/k4MLJetTagger/src/components/Helpers.cpp
@@ -127,61 +127,61 @@ rv::RVec<rv::RVec<float>> from_Jet_to_onnx_input(Jet& jet, const rv::RVec<std::s
 // converstion from FCCAnalyses to key4hep and vice versa
 
 VarMapper::VarMapper() {
-  map_to_FCCAn["pfcand_erel_log"] = "pfcand_erel_log";
-  map_to_FCCAn["pfcand_thetarel"] = "pfcand_thetarel";
-  map_to_FCCAn["pfcand_phirel"] = "pfcand_phirel";
-  map_to_FCCAn["pfcand_cov_omegaomega"] = "pfcand_dptdpt";
-  map_to_FCCAn["pfcand_cov_tanLambdatanLambda"] = "pfcand_detadeta";
-  map_to_FCCAn["pfcand_cov_phiphi"] = "pfcand_dphidphi";
-  map_to_FCCAn["pfcand_cov_d0d0"] = "pfcand_dxydxy";
-  map_to_FCCAn["pfcand_cov_z0z0"] = "pfcand_dzdz";
-  map_to_FCCAn["pfcand_cov_d0z0"] = "pfcand_dxydz";
-  map_to_FCCAn["pfcand_cov_phid0"] = "pfcand_dphidxy";
-  map_to_FCCAn["pfcand_cov_tanLambdaz0"] = "pfcand_dlambdadz";
-  map_to_FCCAn["pfcand_cov_d0omega"] = "pfcand_dxyc";
-  map_to_FCCAn["pfcand_cov_d0tanLambda"] = "pfcand_dxyctgtheta";
-  map_to_FCCAn["pfcand_cov_phiomega"] = "pfcand_phic";
-  map_to_FCCAn["pfcand_cov_phiz0"] = "pfcand_phidz";
-  map_to_FCCAn["pfcand_cov_phitanLambda"] = "pfcand_phictgtheta";
-  map_to_FCCAn["pfcand_cov_omegaz0"] = "pfcand_cdz";
-  map_to_FCCAn["pfcand_cov_omegatanLambda"] = "pfcand_cctgtheta";
-  map_to_FCCAn["pfcand_d0"] = "pfcand_dxy";
-  map_to_FCCAn["pfcand_z0"] = "pfcand_dz";
-  map_to_FCCAn["pfcand_Sip2dVal"] = "pfcand_btagSip2dVal";
-  map_to_FCCAn["pfcand_Sip2dSig"] = "pfcand_btagSip2dSig";
-  map_to_FCCAn["pfcand_Sip3dVal"] = "pfcand_btagSip3dVal";
-  map_to_FCCAn["pfcand_Sip3dSig"] = "pfcand_btagSip3dSig";
-  map_to_FCCAn["pfcand_JetDistVal"] = "pfcand_btagJetDistVal";
-  map_to_FCCAn["pfcand_JetDistSig"] = "pfcand_btagJetDistSig";
-  map_to_FCCAn["pfcand_type"] = "pfcand_type";
-  map_to_FCCAn["pfcand_charge"] = "pfcand_charge";
-  map_to_FCCAn["pfcand_isEl"] = "pfcand_isEl";
-  map_to_FCCAn["pfcand_isMu"] = "pfcand_isMu";
-  map_to_FCCAn["pfcand_isGamma"] = "pfcand_isGamma";
-  map_to_FCCAn["pfcand_isChargedHad"] = "pfcand_isChargedHad";
-  map_to_FCCAn["pfcand_isNeutralHad"] = "pfcand_isNeutralHad";
-  map_to_FCCAn["pfcand_dndx"] = "pfcand_dndx";
-  map_to_FCCAn["pfcand_tof"] = "pfcand_mtof";
-  map_to_FCCAn["pfcand_e"] = "pfcand_e";
-  map_to_FCCAn["pfcand_p"] = "pfcand_p";
+  m_mapToFCCAn["pfcand_erel_log"] = "pfcand_erel_log";
+  m_mapToFCCAn["pfcand_thetarel"] = "pfcand_thetarel";
+  m_mapToFCCAn["pfcand_phirel"] = "pfcand_phirel";
+  m_mapToFCCAn["pfcand_cov_omegaomega"] = "pfcand_dptdpt";
+  m_mapToFCCAn["pfcand_cov_tanLambdatanLambda"] = "pfcand_detadeta";
+  m_mapToFCCAn["pfcand_cov_phiphi"] = "pfcand_dphidphi";
+  m_mapToFCCAn["pfcand_cov_d0d0"] = "pfcand_dxydxy";
+  m_mapToFCCAn["pfcand_cov_z0z0"] = "pfcand_dzdz";
+  m_mapToFCCAn["pfcand_cov_d0z0"] = "pfcand_dxydz";
+  m_mapToFCCAn["pfcand_cov_phid0"] = "pfcand_dphidxy";
+  m_mapToFCCAn["pfcand_cov_tanLambdaz0"] = "pfcand_dlambdadz";
+  m_mapToFCCAn["pfcand_cov_d0omega"] = "pfcand_dxyc";
+  m_mapToFCCAn["pfcand_cov_d0tanLambda"] = "pfcand_dxyctgtheta";
+  m_mapToFCCAn["pfcand_cov_phiomega"] = "pfcand_phic";
+  m_mapToFCCAn["pfcand_cov_phiz0"] = "pfcand_phidz";
+  m_mapToFCCAn["pfcand_cov_phitanLambda"] = "pfcand_phictgtheta";
+  m_mapToFCCAn["pfcand_cov_omegaz0"] = "pfcand_cdz";
+  m_mapToFCCAn["pfcand_cov_omegatanLambda"] = "pfcand_cctgtheta";
+  m_mapToFCCAn["pfcand_d0"] = "pfcand_dxy";
+  m_mapToFCCAn["pfcand_z0"] = "pfcand_dz";
+  m_mapToFCCAn["pfcand_Sip2dVal"] = "pfcand_btagSip2dVal";
+  m_mapToFCCAn["pfcand_Sip2dSig"] = "pfcand_btagSip2dSig";
+  m_mapToFCCAn["pfcand_Sip3dVal"] = "pfcand_btagSip3dVal";
+  m_mapToFCCAn["pfcand_Sip3dSig"] = "pfcand_btagSip3dSig";
+  m_mapToFCCAn["pfcand_JetDistVal"] = "pfcand_btagJetDistVal";
+  m_mapToFCCAn["pfcand_JetDistSig"] = "pfcand_btagJetDistSig";
+  m_mapToFCCAn["pfcand_type"] = "pfcand_type";
+  m_mapToFCCAn["pfcand_charge"] = "pfcand_charge";
+  m_mapToFCCAn["pfcand_isEl"] = "pfcand_isEl";
+  m_mapToFCCAn["pfcand_isMu"] = "pfcand_isMu";
+  m_mapToFCCAn["pfcand_isGamma"] = "pfcand_isGamma";
+  m_mapToFCCAn["pfcand_isChargedHad"] = "pfcand_isChargedHad";
+  m_mapToFCCAn["pfcand_isNeutralHad"] = "pfcand_isNeutralHad";
+  m_mapToFCCAn["pfcand_dndx"] = "pfcand_dndx";
+  m_mapToFCCAn["pfcand_tof"] = "pfcand_mtof";
+  m_mapToFCCAn["pfcand_e"] = "pfcand_e";
+  m_mapToFCCAn["pfcand_p"] = "pfcand_p";
 
   // Create the reverse mapping
-  for (const auto& pair : map_to_FCCAn) {
-    map_to_key4hep[pair.second] = pair.first;
+  for (const auto& pair : m_mapToFCCAn) {
+    m_mapToKey4hep[pair.second] = pair.first;
   }
 }
 
 std::string VarMapper::mapKey4hepToFCCAn(const std::string& key4hepName) const {
-  auto it = map_to_FCCAn.find(key4hepName);
-  if (it != map_to_FCCAn.end()) {
+  auto it = m_mapToFCCAn.find(key4hepName);
+  if (it != m_mapToFCCAn.end()) {
     return it->second;
   }
   return ""; // Return an empty string if not found
 }
 
 std::string VarMapper::mapFCCAnToKey4hep(const std::string& FCCAnName) const {
-  auto it = map_to_key4hep.find(FCCAnName);
-  if (it != map_to_key4hep.end()) {
+  auto it = m_mapToKey4hep.find(FCCAnName);
+  if (it != m_mapToKey4hep.end()) {
     return it->second;
   }
   return ""; // Return an empty string if not found

--- a/k4MLJetTagger/src/components/Helpers.h
+++ b/k4MLJetTagger/src/components/Helpers.h
@@ -108,12 +108,12 @@ private:
   /**
    * @brief Mapping from Key4HEP variable names to FCCAnalyses variable names.
    */
-  std::unordered_map<std::string, std::string> map_to_FCCAn;
+  std::unordered_map<std::string, std::string> m_mapToFCCAn;
 
   /**
    * @brief Mapping from FCCAnalyses variable names to Key4HEP variable names.
    */
-  std::unordered_map<std::string, std::string> map_to_key4hep;
+  std::unordered_map<std::string, std::string> m_mapToKey4hep;
 };
 
 #endif // HELPERS_H

--- a/k4MLJetTagger/src/components/Helpers.h
+++ b/k4MLJetTagger/src/components/Helpers.h
@@ -19,8 +19,6 @@
 #ifndef HELPERS_H
 #define HELPERS_H
 
-#include <fstream>
-#include <iostream>
 #include <nlohmann/json.hpp> // Include a JSON parsing library
 #include <string>
 #include <unordered_map>

--- a/k4MLJetTagger/src/components/JetObsWriter.cpp
+++ b/k4MLJetTagger/src/components/JetObsWriter.cpp
@@ -17,19 +17,11 @@
  * limitations under the License.
  */
 
-#include "Gaudi/Property.h"
 #include "GaudiKernel/MsgStream.h"
-#include "edm4hep/MCParticleCollection.h"
-#include "k4FWCore/Transformer.h"
-#include "k4Interface/IGeoSvc.h" // for Bfield
 #include <edm4hep/ParticleIDCollection.h>
 #include <edm4hep/ReconstructedParticleCollection.h>
 #include <edm4hep/VertexCollection.h>
 
-#include <fstream>
-#include <nlohmann/json.hpp> // Include a JSON parsing library
-
-#include "Helpers.h"
 #include "JetObsWriter.h"
 #include "Structs.h"
 

--- a/k4MLJetTagger/src/components/JetObsWriter.cpp
+++ b/k4MLJetTagger/src/components/JetObsWriter.cpp
@@ -28,8 +28,8 @@
 DECLARE_COMPONENT(JetObsWriter)
 
 JetObsWriter::JetObsWriter(const std::string& name, ISvcLocator* svcLoc) : Gaudi::Algorithm(name, svcLoc) {
-  declareProperty("InputJets", inputJets_handle, "Collection for input Jets");
-  declareProperty("InputPrimaryVertices", inputPrimaryVertices_handle, "Collection for input Primary Vertices");
+  declareProperty("InputJets", m_inputJetsHandle, "Collection for input Jets");
+  declareProperty("InputPrimaryVertices", m_inputPrimaryVerticesHandle, "Collection for input Primary Vertices");
 }
 
 StatusCode JetObsWriter::initialize() {
@@ -42,8 +42,8 @@ StatusCode JetObsWriter::initialize() {
     return StatusCode::FAILURE;
   }
 
-  t_jetcst = new TTree("JetConstituentObservables", "Jet-Constituent Observables");
-  if (m_ths->regTree("/rec/jetconst", t_jetcst).isFailure()) {
+  m_jetcst = new TTree("JetConstituentObservables", "Jet-Constituent Observables");
+  if (m_ths->regTree("/rec/jetconst", m_jetcst).isFailure()) {
     error() << "Couldn't register jet constituent tree" << endmsg;
     return StatusCode::FAILURE;
   }
@@ -51,207 +51,207 @@ StatusCode JetObsWriter::initialize() {
   initializeTree();
 
   // JetObservablesRetriever object
-  retriever = new JetObservablesRetriever();
-  retriever->Bz = 2.0; // hardcoded for now
+  m_retriever = new JetObservablesRetriever();
+  m_retriever->Bz = 2.0; // hardcoded for now
 
   return StatusCode::SUCCESS;
 }
 
 StatusCode JetObsWriter::execute(const EventContext&) const {
-  auto evs = ev_handle.get();
-  evNum = (*evs)[0].getEventNumber();
+  auto evs = m_eventHeaderHandle.get();
+  m_evNum = (*evs)[0].getEventNumber();
   // evNum = 0;
-  info() << "Event number = " << evNum << endmsg;
+  info() << "Event number = " << m_evNum << endmsg;
 
   // Get the pointers to the collections
-  const edm4hep::ReconstructedParticleCollection* jet_coll_ptr = inputJets_handle.get();
-  const edm4hep::VertexCollection* prim_vertex_coll_ptr = inputPrimaryVertices_handle.get();
+  const edm4hep::ReconstructedParticleCollection* jet_coll_ptr = m_inputJetsHandle.get();
+  const edm4hep::VertexCollection* prim_vertex_coll_ptr = m_inputPrimaryVerticesHandle.get();
   // Create references to the collections
   const edm4hep::ReconstructedParticleCollection& jet_coll = *jet_coll_ptr;
   const edm4hep::VertexCollection& prim_vertex_coll = *prim_vertex_coll_ptr;
 
   for (const auto& jet : jet_coll) { // loop over all jets in the event
     cleanTree();
-    Jet j = retriever->retrieve_input_observables(jet, prim_vertex_coll); // get all observables
-    for (const auto& pfc : j.constituents) {                              // loop over all jet constituents / pfcands
-      pfcand_erel_log->push_back(pfc.pfcand_erel_log);
-      pfcand_thetarel->push_back(pfc.pfcand_thetarel);
-      pfcand_phirel->push_back(pfc.pfcand_phirel);
-      pfcand_e->push_back(pfc.pfcand_e);
-      pfcand_p->push_back(pfc.pfcand_p);
-      pfcand_type->push_back(pfc.pfcand_type);
-      pfcand_charge->push_back(pfc.pfcand_charge);
-      pfcand_isEl->push_back(pfc.pfcand_isEl);
-      pfcand_isMu->push_back(pfc.pfcand_isMu);
-      pfcand_isGamma->push_back(pfc.pfcand_isGamma);
-      pfcand_isChargedHad->push_back(pfc.pfcand_isChargedHad);
-      pfcand_isNeutralHad->push_back(pfc.pfcand_isNeutralHad);
-      pfcand_dndx->push_back(pfc.pfcand_dndx);
-      pfcand_tof->push_back(pfc.pfcand_tof);
-      pfcand_cov_omegaomega->push_back(pfc.pfcand_cov_omegaomega);
-      pfcand_cov_tanLambdatanLambda->push_back(pfc.pfcand_cov_tanLambdatanLambda);
-      pfcand_cov_phiphi->push_back(pfc.pfcand_cov_phiphi);
-      pfcand_cov_d0d0->push_back(pfc.pfcand_cov_d0d0);
-      pfcand_cov_z0z0->push_back(pfc.pfcand_cov_z0z0);
-      pfcand_cov_d0z0->push_back(pfc.pfcand_cov_d0z0);
-      pfcand_cov_phid0->push_back(pfc.pfcand_cov_phid0);
-      pfcand_cov_tanLambdaz0->push_back(pfc.pfcand_cov_tanLambdaz0);
-      pfcand_cov_d0omega->push_back(pfc.pfcand_cov_d0omega);
-      pfcand_cov_d0tanLambda->push_back(pfc.pfcand_cov_d0tanLambda);
-      pfcand_cov_phiomega->push_back(pfc.pfcand_cov_phiomega);
-      pfcand_cov_phiz0->push_back(pfc.pfcand_cov_phiz0);
-      pfcand_cov_phitanLambda->push_back(pfc.pfcand_cov_phitanLambda);
-      pfcand_cov_omegaz0->push_back(pfc.pfcand_cov_omegaz0);
-      pfcand_cov_omegatanLambda->push_back(pfc.pfcand_cov_omegatanLambda);
-      pfcand_d0->push_back(pfc.pfcand_d0);
-      pfcand_z0->push_back(pfc.pfcand_z0);
-      pfcand_Sip2dVal->push_back(pfc.pfcand_Sip2dVal);
-      pfcand_Sip2dSig->push_back(pfc.pfcand_Sip2dSig);
-      pfcand_Sip3dVal->push_back(pfc.pfcand_Sip3dVal);
-      pfcand_Sip3dSig->push_back(pfc.pfcand_Sip3dSig);
-      pfcand_JetDistVal->push_back(pfc.pfcand_JetDistVal);
-      pfcand_JetDistSig->push_back(pfc.pfcand_JetDistSig);
+    Jet j = m_retriever->retrieve_input_observables(jet, prim_vertex_coll); // get all observables
+    for (const auto& pfc : j.constituents) {                                // loop over all jet constituents / pfcands
+      m_pfcandErelLog->push_back(pfc.pfcand_erel_log);
+      m_pfcandThetarel->push_back(pfc.pfcand_thetarel);
+      m_pfcandPhirel->push_back(pfc.pfcand_phirel);
+      m_pfcandE->push_back(pfc.pfcand_e);
+      m_pfcandP->push_back(pfc.pfcand_p);
+      m_pfcandType->push_back(pfc.pfcand_type);
+      m_pfcandCharge->push_back(pfc.pfcand_charge);
+      m_pfcandIsEl->push_back(pfc.pfcand_isEl);
+      m_pfcandIsMu->push_back(pfc.pfcand_isMu);
+      m_pfcandIsGamma->push_back(pfc.pfcand_isGamma);
+      m_pfcandIsChargedHad->push_back(pfc.pfcand_isChargedHad);
+      m_pfcandIsNeutralHad->push_back(pfc.pfcand_isNeutralHad);
+      m_pfcandDndx->push_back(pfc.pfcand_dndx);
+      m_pfcandTof->push_back(pfc.pfcand_tof);
+      m_pfcandCovOmegaOmega->push_back(pfc.pfcand_cov_omegaomega);
+      m_pfcandCovTanLambdaTanLambda->push_back(pfc.pfcand_cov_tanLambdatanLambda);
+      m_pfcandCovPhiPhi->push_back(pfc.pfcand_cov_phiphi);
+      m_pfcandCovD0D0->push_back(pfc.pfcand_cov_d0d0);
+      m_pfcandCovZ0Z0->push_back(pfc.pfcand_cov_z0z0);
+      m_pfcandCovD0Z0->push_back(pfc.pfcand_cov_d0z0);
+      m_pfcandCovPhiD0->push_back(pfc.pfcand_cov_phid0);
+      m_pfcandCovTanLambdaZ0->push_back(pfc.pfcand_cov_tanLambdaz0);
+      m_pfcandCovD0Omega->push_back(pfc.pfcand_cov_d0omega);
+      m_pfcandCovD0TanLambda->push_back(pfc.pfcand_cov_d0tanLambda);
+      m_pfcandCovPhiOmega->push_back(pfc.pfcand_cov_phiomega);
+      m_pfcandCovPhiZ0->push_back(pfc.pfcand_cov_phiz0);
+      m_pfcandCovPhiTanLambda->push_back(pfc.pfcand_cov_phitanLambda);
+      m_pfcandCovOmegaZ0->push_back(pfc.pfcand_cov_omegaz0);
+      m_pfcandCovOmegaTanLambda->push_back(pfc.pfcand_cov_omegatanLambda);
+      m_pfcandD0->push_back(pfc.pfcand_d0);
+      m_pfcandZ0->push_back(pfc.pfcand_z0);
+      m_pfcandSip2dVal->push_back(pfc.pfcand_Sip2dVal);
+      m_pfcandSip2dSig->push_back(pfc.pfcand_Sip2dSig);
+      m_pfcandSip3dVal->push_back(pfc.pfcand_Sip3dVal);
+      m_pfcandSip3dSig->push_back(pfc.pfcand_Sip3dSig);
+      m_pfcandJetDistVal->push_back(pfc.pfcand_JetDistVal);
+      m_pfcandJetDistSig->push_back(pfc.pfcand_JetDistSig);
     }
     // PV variables
-    const edm4hep::Vector3f prim_vertex = retriever->get_primary_vertex(prim_vertex_coll);
-    jet_PV_x = prim_vertex.x;
-    jet_PV_y = prim_vertex.y;
-    jet_PV_z = prim_vertex.z;
+    const edm4hep::Vector3f prim_vertex = m_retriever->get_primary_vertex(prim_vertex_coll);
+    m_jetPVx = prim_vertex.x;
+    m_jetPVy = prim_vertex.y;
+    m_jetPVz = prim_vertex.z;
 
-    t_jetcst->Fill();
+    m_jetcst->Fill();
   }
 
   return StatusCode::SUCCESS;
 }
 
 void JetObsWriter::initializeTree() {
-  pfcand_erel_log = new std::vector<float>();
-  pfcand_thetarel = new std::vector<float>();
-  pfcand_phirel = new std::vector<float>();
-  pfcand_e = new std::vector<float>();
-  pfcand_p = new std::vector<float>();
-  pfcand_type = new std::vector<int>();
-  pfcand_charge = new std::vector<int>();
-  pfcand_isEl = new std::vector<int>();
-  pfcand_isMu = new std::vector<int>();
-  pfcand_isGamma = new std::vector<int>();
-  pfcand_isChargedHad = new std::vector<int>();
-  pfcand_isNeutralHad = new std::vector<int>();
-  pfcand_dndx = new std::vector<float>();
-  pfcand_tof = new std::vector<float>();
-  pfcand_cov_omegaomega = new std::vector<float>();
-  pfcand_cov_tanLambdatanLambda = new std::vector<float>();
-  pfcand_cov_phiphi = new std::vector<float>();
-  pfcand_cov_d0d0 = new std::vector<float>();
-  pfcand_cov_z0z0 = new std::vector<float>();
-  pfcand_cov_d0z0 = new std::vector<float>();
-  pfcand_cov_phid0 = new std::vector<float>();
-  pfcand_cov_tanLambdaz0 = new std::vector<float>();
-  pfcand_cov_d0omega = new std::vector<float>();
-  pfcand_cov_d0tanLambda = new std::vector<float>();
-  pfcand_cov_phiomega = new std::vector<float>();
-  pfcand_cov_phiz0 = new std::vector<float>();
-  pfcand_cov_phitanLambda = new std::vector<float>();
-  pfcand_cov_omegaz0 = new std::vector<float>();
-  pfcand_cov_omegatanLambda = new std::vector<float>();
-  pfcand_d0 = new std::vector<float>();
-  pfcand_z0 = new std::vector<float>();
-  pfcand_Sip2dVal = new std::vector<float>();
-  pfcand_Sip2dSig = new std::vector<float>();
-  pfcand_Sip3dVal = new std::vector<float>();
-  pfcand_Sip3dSig = new std::vector<float>();
-  pfcand_JetDistVal = new std::vector<float>();
-  pfcand_JetDistSig = new std::vector<float>();
+  m_pfcandErelLog = new std::vector<float>();
+  m_pfcandThetarel = new std::vector<float>();
+  m_pfcandPhirel = new std::vector<float>();
+  m_pfcandE = new std::vector<float>();
+  m_pfcandP = new std::vector<float>();
+  m_pfcandType = new std::vector<int>();
+  m_pfcandCharge = new std::vector<int>();
+  m_pfcandIsEl = new std::vector<int>();
+  m_pfcandIsMu = new std::vector<int>();
+  m_pfcandIsGamma = new std::vector<int>();
+  m_pfcandIsChargedHad = new std::vector<int>();
+  m_pfcandIsNeutralHad = new std::vector<int>();
+  m_pfcandDndx = new std::vector<float>();
+  m_pfcandTof = new std::vector<float>();
+  m_pfcandCovOmegaOmega = new std::vector<float>();
+  m_pfcandCovTanLambdaTanLambda = new std::vector<float>();
+  m_pfcandCovPhiPhi = new std::vector<float>();
+  m_pfcandCovD0D0 = new std::vector<float>();
+  m_pfcandCovZ0Z0 = new std::vector<float>();
+  m_pfcandCovD0Z0 = new std::vector<float>();
+  m_pfcandCovPhiD0 = new std::vector<float>();
+  m_pfcandCovTanLambdaZ0 = new std::vector<float>();
+  m_pfcandCovD0Omega = new std::vector<float>();
+  m_pfcandCovD0TanLambda = new std::vector<float>();
+  m_pfcandCovPhiOmega = new std::vector<float>();
+  m_pfcandCovPhiZ0 = new std::vector<float>();
+  m_pfcandCovPhiTanLambda = new std::vector<float>();
+  m_pfcandCovOmegaZ0 = new std::vector<float>();
+  m_pfcandCovOmegaTanLambda = new std::vector<float>();
+  m_pfcandD0 = new std::vector<float>();
+  m_pfcandZ0 = new std::vector<float>();
+  m_pfcandSip2dVal = new std::vector<float>();
+  m_pfcandSip2dSig = new std::vector<float>();
+  m_pfcandSip3dVal = new std::vector<float>();
+  m_pfcandSip3dSig = new std::vector<float>();
+  m_pfcandJetDistVal = new std::vector<float>();
+  m_pfcandJetDistSig = new std::vector<float>();
 
-  t_jetcst->Branch("pfcand_erel_log", &pfcand_erel_log);
-  t_jetcst->Branch("pfcand_thetarel", &pfcand_thetarel);
-  t_jetcst->Branch("pfcand_phirel", &pfcand_phirel);
-  t_jetcst->Branch("pfcand_e", &pfcand_e);
-  t_jetcst->Branch("pfcand_p", &pfcand_p);
-  t_jetcst->Branch("pfcand_type", &pfcand_type);
-  t_jetcst->Branch("pfcand_charge", &pfcand_charge);
-  t_jetcst->Branch("pfcand_isEl", &pfcand_isEl);
-  t_jetcst->Branch("pfcand_isMu", &pfcand_isMu);
-  t_jetcst->Branch("pfcand_isGamma", &pfcand_isGamma);
-  t_jetcst->Branch("pfcand_isChargedHad", &pfcand_isChargedHad);
-  t_jetcst->Branch("pfcand_isNeutralHad", &pfcand_isNeutralHad);
-  t_jetcst->Branch("pfcand_dndx", &pfcand_dndx);
-  t_jetcst->Branch("pfcand_tof", &pfcand_tof);
-  t_jetcst->Branch("pfcand_cov_omegaomega", &pfcand_cov_omegaomega);
-  t_jetcst->Branch("pfcand_cov_tanLambdatanLambda", &pfcand_cov_tanLambdatanLambda);
-  t_jetcst->Branch("pfcand_cov_phiphi", &pfcand_cov_phiphi);
-  t_jetcst->Branch("pfcand_cov_d0d0", &pfcand_cov_d0d0);
-  t_jetcst->Branch("pfcand_cov_z0z0", &pfcand_cov_z0z0);
-  t_jetcst->Branch("pfcand_cov_d0z0", &pfcand_cov_d0z0);
-  t_jetcst->Branch("pfcand_cov_phid0", &pfcand_cov_phid0);
-  t_jetcst->Branch("pfcand_cov_tanLambdaz0", &pfcand_cov_tanLambdaz0);
-  t_jetcst->Branch("pfcand_cov_d0omega", &pfcand_cov_d0omega);
-  t_jetcst->Branch("pfcand_cov_d0tanLambda", &pfcand_cov_d0tanLambda);
-  t_jetcst->Branch("pfcand_cov_phiomega", &pfcand_cov_phiomega);
-  t_jetcst->Branch("pfcand_cov_phiz0", &pfcand_cov_phiz0);
-  t_jetcst->Branch("pfcand_cov_phitanLambda", &pfcand_cov_phitanLambda);
-  t_jetcst->Branch("pfcand_cov_omegaz0", &pfcand_cov_omegaz0);
-  t_jetcst->Branch("pfcand_cov_omegatanLambda", &pfcand_cov_omegatanLambda);
-  t_jetcst->Branch("pfcand_d0", &pfcand_d0);
-  t_jetcst->Branch("pfcand_z0", &pfcand_z0);
-  t_jetcst->Branch("pfcand_Sip2dVal", &pfcand_Sip2dVal);
-  t_jetcst->Branch("pfcand_Sip2dSig", &pfcand_Sip2dSig);
-  t_jetcst->Branch("pfcand_Sip3dVal", &pfcand_Sip3dVal);
-  t_jetcst->Branch("pfcand_Sip3dSig", &pfcand_Sip3dSig);
-  t_jetcst->Branch("pfcand_JetDistVal", &pfcand_JetDistVal);
-  t_jetcst->Branch("pfcand_JetDistSig", &pfcand_JetDistSig);
+  m_jetcst->Branch("pfcand_erel_log", &m_pfcandErelLog);
+  m_jetcst->Branch("pfcand_thetarel", &m_pfcandThetarel);
+  m_jetcst->Branch("pfcand_phirel", &m_pfcandPhirel);
+  m_jetcst->Branch("pfcand_e", &m_pfcandE);
+  m_jetcst->Branch("pfcand_p", &m_pfcandP);
+  m_jetcst->Branch("pfcand_type", &m_pfcandType);
+  m_jetcst->Branch("pfcand_charge", &m_pfcandCharge);
+  m_jetcst->Branch("pfcand_isEl", &m_pfcandIsEl);
+  m_jetcst->Branch("pfcand_isMu", &m_pfcandIsMu);
+  m_jetcst->Branch("pfcand_isGamma", &m_pfcandIsGamma);
+  m_jetcst->Branch("pfcand_isChargedHad", &m_pfcandIsChargedHad);
+  m_jetcst->Branch("pfcand_isNeutralHad", &m_pfcandIsNeutralHad);
+  m_jetcst->Branch("pfcand_dndx", &m_pfcandDndx);
+  m_jetcst->Branch("pfcand_tof", &m_pfcandTof);
+  m_jetcst->Branch("pfcand_cov_omegaomega", &m_pfcandCovOmegaOmega);
+  m_jetcst->Branch("pfcand_cov_tanLambdatanLambda", &m_pfcandCovTanLambdaTanLambda);
+  m_jetcst->Branch("pfcand_cov_phiphi", &m_pfcandCovPhiPhi);
+  m_jetcst->Branch("pfcand_cov_d0d0", &m_pfcandCovD0D0);
+  m_jetcst->Branch("pfcand_cov_z0z0", &m_pfcandCovZ0Z0);
+  m_jetcst->Branch("pfcand_cov_d0z0", &m_pfcandCovD0Z0);
+  m_jetcst->Branch("pfcand_cov_phid0", &m_pfcandCovPhiD0);
+  m_jetcst->Branch("pfcand_cov_tanLambdaz0", &m_pfcandCovTanLambdaZ0);
+  m_jetcst->Branch("pfcand_cov_d0omega", &m_pfcandCovD0Omega);
+  m_jetcst->Branch("pfcand_cov_d0tanLambda", &m_pfcandCovD0TanLambda);
+  m_jetcst->Branch("pfcand_cov_phiomega", &m_pfcandCovPhiOmega);
+  m_jetcst->Branch("pfcand_cov_phiz0", &m_pfcandCovPhiZ0);
+  m_jetcst->Branch("pfcand_cov_phitanLambda", &m_pfcandCovPhiTanLambda);
+  m_jetcst->Branch("pfcand_cov_omegaz0", &m_pfcandCovOmegaZ0);
+  m_jetcst->Branch("pfcand_cov_omegatanLambda", &m_pfcandCovOmegaTanLambda);
+  m_jetcst->Branch("pfcand_d0", &m_pfcandD0);
+  m_jetcst->Branch("pfcand_z0", &m_pfcandZ0);
+  m_jetcst->Branch("pfcand_Sip2dVal", &m_pfcandSip2dVal);
+  m_jetcst->Branch("pfcand_Sip2dSig", &m_pfcandSip2dSig);
+  m_jetcst->Branch("pfcand_Sip3dVal", &m_pfcandSip3dVal);
+  m_jetcst->Branch("pfcand_Sip3dSig", &m_pfcandSip3dSig);
+  m_jetcst->Branch("pfcand_JetDistVal", &m_pfcandJetDistVal);
+  m_jetcst->Branch("pfcand_JetDistSig", &m_pfcandJetDistSig);
 
   // PV variables
-  t_jetcst->Branch("jet_PV_x", &jet_PV_x);
-  t_jetcst->Branch("jet_PV_y", &jet_PV_y);
-  t_jetcst->Branch("jet_PV_z", &jet_PV_z);
+  m_jetcst->Branch("jet_PV_x", &m_jetPVx);
+  m_jetcst->Branch("jet_PV_y", &m_jetPVy);
+  m_jetcst->Branch("jet_PV_z", &m_jetPVz);
 
   return;
 }
 
 void JetObsWriter::cleanTree() const {
-  pfcand_erel_log->clear();
-  pfcand_thetarel->clear();
-  pfcand_phirel->clear();
-  pfcand_e->clear();
-  pfcand_p->clear();
-  pfcand_type->clear();
-  pfcand_charge->clear();
-  pfcand_isEl->clear();
-  pfcand_isMu->clear();
-  pfcand_isGamma->clear();
-  pfcand_isChargedHad->clear();
-  pfcand_isNeutralHad->clear();
-  pfcand_dndx->clear();
-  pfcand_tof->clear();
-  pfcand_cov_omegaomega->clear();
-  pfcand_cov_tanLambdatanLambda->clear();
-  pfcand_cov_phiphi->clear();
-  pfcand_cov_d0d0->clear();
-  pfcand_cov_z0z0->clear();
-  pfcand_cov_d0z0->clear();
-  pfcand_cov_phid0->clear();
-  pfcand_cov_tanLambdaz0->clear();
-  pfcand_cov_d0omega->clear();
-  pfcand_cov_d0tanLambda->clear();
-  pfcand_cov_phiomega->clear();
-  pfcand_cov_phiz0->clear();
-  pfcand_cov_phitanLambda->clear();
-  pfcand_cov_omegaz0->clear();
-  pfcand_cov_omegatanLambda->clear();
-  pfcand_d0->clear();
-  pfcand_z0->clear();
-  pfcand_Sip2dVal->clear();
-  pfcand_Sip2dSig->clear();
-  pfcand_Sip3dVal->clear();
-  pfcand_Sip3dSig->clear();
-  pfcand_JetDistVal->clear();
-  pfcand_JetDistSig->clear();
+  m_pfcandErelLog->clear();
+  m_pfcandThetarel->clear();
+  m_pfcandPhirel->clear();
+  m_pfcandE->clear();
+  m_pfcandP->clear();
+  m_pfcandType->clear();
+  m_pfcandCharge->clear();
+  m_pfcandIsEl->clear();
+  m_pfcandIsMu->clear();
+  m_pfcandIsGamma->clear();
+  m_pfcandIsChargedHad->clear();
+  m_pfcandIsNeutralHad->clear();
+  m_pfcandDndx->clear();
+  m_pfcandTof->clear();
+  m_pfcandCovOmegaOmega->clear();
+  m_pfcandCovTanLambdaTanLambda->clear();
+  m_pfcandCovPhiPhi->clear();
+  m_pfcandCovD0D0->clear();
+  m_pfcandCovZ0Z0->clear();
+  m_pfcandCovD0Z0->clear();
+  m_pfcandCovPhiD0->clear();
+  m_pfcandCovTanLambdaZ0->clear();
+  m_pfcandCovD0Omega->clear();
+  m_pfcandCovD0TanLambda->clear();
+  m_pfcandCovPhiOmega->clear();
+  m_pfcandCovPhiZ0->clear();
+  m_pfcandCovPhiTanLambda->clear();
+  m_pfcandCovOmegaZ0->clear();
+  m_pfcandCovOmegaTanLambda->clear();
+  m_pfcandD0->clear();
+  m_pfcandZ0->clear();
+  m_pfcandSip2dVal->clear();
+  m_pfcandSip2dSig->clear();
+  m_pfcandSip3dVal->clear();
+  m_pfcandSip3dSig->clear();
+  m_pfcandJetDistVal->clear();
+  m_pfcandJetDistSig->clear();
 
   float dummy_value = -999.0;
-  jet_PV_x = dummy_value;
-  jet_PV_y = dummy_value;
-  jet_PV_z = dummy_value;
+  m_jetPVx = dummy_value;
+  m_jetPVy = dummy_value;
+  m_jetPVz = dummy_value;
 
   return;
 }

--- a/k4MLJetTagger/src/components/JetObsWriter.h
+++ b/k4MLJetTagger/src/components/JetObsWriter.h
@@ -52,43 +52,43 @@ public:
   JetObsWriter(const std::string& name, ISvcLocator* svcLoc);
   /// Destructor.
   ~JetObsWriter() {
-    delete pfcand_erel_log;
-    delete pfcand_thetarel;
-    delete pfcand_phirel;
-    delete pfcand_e;
-    delete pfcand_p;
-    delete pfcand_type;
-    delete pfcand_charge;
-    delete pfcand_isEl;
-    delete pfcand_isMu;
-    delete pfcand_isGamma;
-    delete pfcand_isChargedHad;
-    delete pfcand_isNeutralHad;
-    delete pfcand_dndx;
-    delete pfcand_tof;
-    delete pfcand_cov_omegaomega;
-    delete pfcand_cov_tanLambdatanLambda;
-    delete pfcand_cov_phiphi;
-    delete pfcand_cov_d0d0;
-    delete pfcand_cov_z0z0;
-    delete pfcand_cov_d0z0;
-    delete pfcand_cov_phid0;
-    delete pfcand_cov_tanLambdaz0;
-    delete pfcand_cov_d0omega;
-    delete pfcand_cov_d0tanLambda;
-    delete pfcand_cov_phiomega;
-    delete pfcand_cov_phiz0;
-    delete pfcand_cov_phitanLambda;
-    delete pfcand_cov_omegaz0;
-    delete pfcand_cov_omegatanLambda;
-    delete pfcand_d0;
-    delete pfcand_z0;
-    delete pfcand_Sip2dVal;
-    delete pfcand_Sip2dSig;
-    delete pfcand_Sip3dVal;
-    delete pfcand_Sip3dSig;
-    delete pfcand_JetDistVal;
-    delete pfcand_JetDistSig;
+    delete m_pfcandErelLog;
+    delete m_pfcandThetarel;
+    delete m_pfcandPhirel;
+    delete m_pfcandE;
+    delete m_pfcandP;
+    delete m_pfcandType;
+    delete m_pfcandCharge;
+    delete m_pfcandIsEl;
+    delete m_pfcandIsMu;
+    delete m_pfcandIsGamma;
+    delete m_pfcandIsChargedHad;
+    delete m_pfcandIsNeutralHad;
+    delete m_pfcandDndx;
+    delete m_pfcandTof;
+    delete m_pfcandCovOmegaOmega;
+    delete m_pfcandCovTanLambdaTanLambda;
+    delete m_pfcandCovPhiPhi;
+    delete m_pfcandCovD0D0;
+    delete m_pfcandCovZ0Z0;
+    delete m_pfcandCovD0Z0;
+    delete m_pfcandCovPhiD0;
+    delete m_pfcandCovTanLambdaZ0;
+    delete m_pfcandCovD0Omega;
+    delete m_pfcandCovD0TanLambda;
+    delete m_pfcandCovPhiOmega;
+    delete m_pfcandCovPhiZ0;
+    delete m_pfcandCovPhiTanLambda;
+    delete m_pfcandCovOmegaZ0;
+    delete m_pfcandCovOmegaTanLambda;
+    delete m_pfcandD0;
+    delete m_pfcandZ0;
+    delete m_pfcandSip2dVal;
+    delete m_pfcandSip2dSig;
+    delete m_pfcandSip3dVal;
+    delete m_pfcandSip3dSig;
+    delete m_pfcandJetDistVal;
+    delete m_pfcandJetDistSig;
   };
   /// Initialize.
   virtual StatusCode initialize();
@@ -102,62 +102,63 @@ public:
   virtual StatusCode finalize();
 
 private:
-  mutable DataHandle<edm4hep::EventHeaderCollection> ev_handle{"EventHeader", Gaudi::DataHandle::Reader, this};
-  mutable DataHandle<edm4hep::ReconstructedParticleCollection> inputJets_handle{"InputJets", Gaudi::DataHandle::Reader,
-                                                                                this};
-  mutable DataHandle<edm4hep::VertexCollection> inputPrimaryVertices_handle{"InputPrimaryVertices",
-                                                                            Gaudi::DataHandle::Reader, this};
+  mutable DataHandle<edm4hep::EventHeaderCollection> m_eventHeaderHandle{"EventHeader", Gaudi::DataHandle::Reader,
+                                                                         this};
+  mutable DataHandle<edm4hep::ReconstructedParticleCollection> m_inputJetsHandle{"InputJets", Gaudi::DataHandle::Reader,
+                                                                                 this};
+  mutable DataHandle<edm4hep::VertexCollection> m_inputPrimaryVerticesHandle{"InputPrimaryVertices",
+                                                                             Gaudi::DataHandle::Reader, this};
 
-  mutable JetObservablesRetriever* retriever;
+  mutable JetObservablesRetriever* m_retriever;
 
   SmartIF<ITHistSvc> m_ths; ///< THistogram service
 
-  mutable TTree* t_jetcst{nullptr};
+  mutable TTree* m_jetcst{nullptr};
 
-  mutable std::vector<float>* pfcand_erel_log = nullptr;
-  mutable std::vector<float>* pfcand_thetarel = nullptr;
-  mutable std::vector<float>* pfcand_phirel = nullptr;
-  mutable std::vector<float>* pfcand_e = nullptr;
-  mutable std::vector<float>* pfcand_p = nullptr;
-  mutable std::vector<int>* pfcand_type = nullptr;
-  mutable std::vector<int>* pfcand_charge = nullptr;
-  mutable std::vector<int>* pfcand_isEl = nullptr;
-  mutable std::vector<int>* pfcand_isMu = nullptr;
-  mutable std::vector<int>* pfcand_isGamma = nullptr;
-  mutable std::vector<int>* pfcand_isChargedHad = nullptr;
-  mutable std::vector<int>* pfcand_isNeutralHad = nullptr;
-  mutable std::vector<float>* pfcand_dndx = nullptr;
-  mutable std::vector<float>* pfcand_tof = nullptr;
-  mutable std::vector<float>* pfcand_cov_omegaomega = nullptr;
-  mutable std::vector<float>* pfcand_cov_tanLambdatanLambda = nullptr;
-  mutable std::vector<float>* pfcand_cov_phiphi = nullptr;
-  mutable std::vector<float>* pfcand_cov_d0d0 = nullptr;
-  mutable std::vector<float>* pfcand_cov_z0z0 = nullptr;
-  mutable std::vector<float>* pfcand_cov_d0z0 = nullptr;
-  mutable std::vector<float>* pfcand_cov_phid0 = nullptr;
-  mutable std::vector<float>* pfcand_cov_tanLambdaz0 = nullptr;
-  mutable std::vector<float>* pfcand_cov_d0omega = nullptr;
-  mutable std::vector<float>* pfcand_cov_d0tanLambda = nullptr;
-  mutable std::vector<float>* pfcand_cov_phiomega = nullptr;
-  mutable std::vector<float>* pfcand_cov_phiz0 = nullptr;
-  mutable std::vector<float>* pfcand_cov_phitanLambda = nullptr;
-  mutable std::vector<float>* pfcand_cov_omegaz0 = nullptr;
-  mutable std::vector<float>* pfcand_cov_omegatanLambda = nullptr;
-  mutable std::vector<float>* pfcand_d0 = nullptr;
-  mutable std::vector<float>* pfcand_z0 = nullptr;
-  mutable std::vector<float>* pfcand_Sip2dVal = nullptr;
-  mutable std::vector<float>* pfcand_Sip2dSig = nullptr;
-  mutable std::vector<float>* pfcand_Sip3dVal = nullptr;
-  mutable std::vector<float>* pfcand_Sip3dSig = nullptr;
-  mutable std::vector<float>* pfcand_JetDistVal = nullptr;
-  mutable std::vector<float>* pfcand_JetDistSig = nullptr;
+  mutable std::vector<float>* m_pfcandErelLog = nullptr;
+  mutable std::vector<float>* m_pfcandThetarel = nullptr;
+  mutable std::vector<float>* m_pfcandPhirel = nullptr;
+  mutable std::vector<float>* m_pfcandE = nullptr;
+  mutable std::vector<float>* m_pfcandP = nullptr;
+  mutable std::vector<int>* m_pfcandType = nullptr;
+  mutable std::vector<int>* m_pfcandCharge = nullptr;
+  mutable std::vector<int>* m_pfcandIsEl = nullptr;
+  mutable std::vector<int>* m_pfcandIsMu = nullptr;
+  mutable std::vector<int>* m_pfcandIsGamma = nullptr;
+  mutable std::vector<int>* m_pfcandIsChargedHad = nullptr;
+  mutable std::vector<int>* m_pfcandIsNeutralHad = nullptr;
+  mutable std::vector<float>* m_pfcandDndx = nullptr;
+  mutable std::vector<float>* m_pfcandTof = nullptr;
+  mutable std::vector<float>* m_pfcandCovOmegaOmega = nullptr;
+  mutable std::vector<float>* m_pfcandCovTanLambdaTanLambda = nullptr;
+  mutable std::vector<float>* m_pfcandCovPhiPhi = nullptr;
+  mutable std::vector<float>* m_pfcandCovD0D0 = nullptr;
+  mutable std::vector<float>* m_pfcandCovZ0Z0 = nullptr;
+  mutable std::vector<float>* m_pfcandCovD0Z0 = nullptr;
+  mutable std::vector<float>* m_pfcandCovPhiD0 = nullptr;
+  mutable std::vector<float>* m_pfcandCovTanLambdaZ0 = nullptr;
+  mutable std::vector<float>* m_pfcandCovD0Omega = nullptr;
+  mutable std::vector<float>* m_pfcandCovD0TanLambda = nullptr;
+  mutable std::vector<float>* m_pfcandCovPhiOmega = nullptr;
+  mutable std::vector<float>* m_pfcandCovPhiZ0 = nullptr;
+  mutable std::vector<float>* m_pfcandCovPhiTanLambda = nullptr;
+  mutable std::vector<float>* m_pfcandCovOmegaZ0 = nullptr;
+  mutable std::vector<float>* m_pfcandCovOmegaTanLambda = nullptr;
+  mutable std::vector<float>* m_pfcandD0 = nullptr;
+  mutable std::vector<float>* m_pfcandZ0 = nullptr;
+  mutable std::vector<float>* m_pfcandSip2dVal = nullptr;
+  mutable std::vector<float>* m_pfcandSip2dSig = nullptr;
+  mutable std::vector<float>* m_pfcandSip3dVal = nullptr;
+  mutable std::vector<float>* m_pfcandSip3dSig = nullptr;
+  mutable std::vector<float>* m_pfcandJetDistVal = nullptr;
+  mutable std::vector<float>* m_pfcandJetDistSig = nullptr;
   // Not input to network but good to check:
-  mutable float jet_PV_x;
-  mutable float jet_PV_y;
-  mutable float jet_PV_z;
-  mutable int jet_PV_id;
+  mutable float m_jetPVx;
+  mutable float m_jetPVy;
+  mutable float m_jetPVz;
+  mutable int m_jetPVid;
 
-  mutable std::int32_t evNum;
+  mutable std::int32_t m_evNum;
 };
 
 #endif // JETOBSWRITER_H

--- a/k4MLJetTagger/src/components/JetObsWriter.h
+++ b/k4MLJetTagger/src/components/JetObsWriter.h
@@ -22,14 +22,10 @@
 #include "Gaudi/Algorithm.h"
 #include "GaudiKernel/ITHistSvc.h"
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
 
 #include <edm4hep/EventHeaderCollection.h>
 #include <edm4hep/ReconstructedParticleCollection.h>
 #include <edm4hep/VertexCollection.h>
-
-#include "TGraph.h"
-#include "TH1F.h"
 
 #include "JetObservablesRetriever.h"
 

--- a/k4MLJetTagger/src/components/JetTagWriter.cpp
+++ b/k4MLJetTagger/src/components/JetTagWriter.cpp
@@ -17,20 +17,10 @@
  * limitations under the License.
  */
 
-#include "Gaudi/Property.h"
-#include "GaudiKernel/MsgStream.h"
-#include "k4FWCore/Transformer.h"
+#include "JetTagWriter.h"
+
 #include <edm4hep/ParticleIDCollection.h>
 #include <edm4hep/utils/ParticleIDUtils.h>
-#include <podio/Frame.h>
-
-#include <fstream>
-#include <nlohmann/json.hpp> // Include a JSON parsing library
-
-#include "Helpers.h"
-#include "JetObservablesRetriever.h"
-#include "JetTagWriter.h"
-#include "Structs.h"
 
 DECLARE_COMPONENT(JetTagWriter)
 

--- a/k4MLJetTagger/src/components/JetTagWriter.cpp
+++ b/k4MLJetTagger/src/components/JetTagWriter.cpp
@@ -25,15 +25,15 @@
 DECLARE_COMPONENT(JetTagWriter)
 
 JetTagWriter::JetTagWriter(const std::string& name, ISvcLocator* svcLoc) : Gaudi::Algorithm(name, svcLoc) {
-  declareProperty("InputJets", jets_handle, "Collection of refined jets");
-  declareProperty("RefinedJetTag_G", reco_jettag_G_handle, "Collection for jet flavor tag G");
-  declareProperty("RefinedJetTag_U", reco_jettag_U_handle, "Collection for jet flavor tag U");
-  declareProperty("RefinedJetTag_D", reco_jettag_D_handle, "Collection for jet flavor tag D");
-  declareProperty("RefinedJetTag_S", reco_jettag_S_handle, "Collection for jet flavor tag S");
-  declareProperty("RefinedJetTag_C", reco_jettag_C_handle, "Collection for jet flavor tag C");
-  declareProperty("RefinedJetTag_B", reco_jettag_B_handle, "Collection for jet flavor tag B");
-  declareProperty("RefinedJetTag_TAU", reco_jettag_TAU_handle, "Collection for jet flavor tag TAU");
-  declareProperty("MCJetTag", mc_jettag_handle, "Collection for MC Jet Tag");
+  declareProperty("InputJets", m_jetsHandle, "Collection of refined jets");
+  declareProperty("RefinedJetTag_G", m_recoJettagGHandle, "Collection for jet flavor tag G");
+  declareProperty("RefinedJetTag_U", m_recoJettagUHandle, "Collection for jet flavor tag U");
+  declareProperty("RefinedJetTag_D", m_recoJettagDHandle, "Collection for jet flavor tag D");
+  declareProperty("RefinedJetTag_S", m_recoJettagSHandle, "Collection for jet flavor tag S");
+  declareProperty("RefinedJetTag_C", m_recoJettagCHandle, "Collection for jet flavor tag C");
+  declareProperty("RefinedJetTag_B", m_recoJettagBHandle, "Collection for jet flavor tag B");
+  declareProperty("RefinedJetTag_TAU", m_recoJettagTauHandle, "Collection for jet flavor tag TAU");
+  declareProperty("MCJetTag", m_mcJettagHandle, "Collection for MC Jet Tag");
 }
 
 StatusCode JetTagWriter::initialize() {
@@ -46,8 +46,8 @@ StatusCode JetTagWriter::initialize() {
     return StatusCode::FAILURE;
   }
 
-  t_jettag = new TTree("JetTags", "Jet flavor tags");
-  if (m_ths->regTree("/rec/jetflags", t_jettag).isFailure()) {
+  m_jettag = new TTree("JetTags", "Jet flavor tags");
+  if (m_ths->regTree("/rec/jetflags", m_jettag).isFailure()) {
     error() << "Couldn't register jet flags tree" << endmsg;
     return StatusCode::FAILURE;
   }
@@ -58,21 +58,21 @@ StatusCode JetTagWriter::initialize() {
 }
 
 StatusCode JetTagWriter::execute(const EventContext&) const {
-  auto evs = ev_handle.get();
-  evNum = (*evs)[0].getEventNumber();
+  auto evs = m_eventHeaderHandle.get();
+  m_evNum = (*evs)[0].getEventNumber();
   // evNum = 0;
-  info() << "Starting to write jet tags of event " << evNum << " into a tree..." << endmsg;
+  info() << "Starting to write jet tags of event " << m_evNum << " into a tree..." << endmsg;
 
   // Get the pointers to the collections
-  const edm4hep::ReconstructedParticleCollection* jet_coll_ptr = jets_handle.get();
-  const edm4hep::ParticleIDCollection* reco_jettag_G_coll_ptr = reco_jettag_G_handle.get();
-  const edm4hep::ParticleIDCollection* reco_jettag_U_coll_ptr = reco_jettag_U_handle.get();
-  const edm4hep::ParticleIDCollection* reco_jettag_D_coll_ptr = reco_jettag_D_handle.get();
-  const edm4hep::ParticleIDCollection* reco_jettag_S_coll_ptr = reco_jettag_S_handle.get();
-  const edm4hep::ParticleIDCollection* reco_jettag_C_coll_ptr = reco_jettag_C_handle.get();
-  const edm4hep::ParticleIDCollection* reco_jettag_B_coll_ptr = reco_jettag_B_handle.get();
-  const edm4hep::ParticleIDCollection* reco_jettag_TAU_coll_ptr = reco_jettag_TAU_handle.get();
-  const edm4hep::ParticleIDCollection* mc_jettag_coll_ptr = mc_jettag_handle.get();
+  const edm4hep::ReconstructedParticleCollection* jet_coll_ptr = m_jetsHandle.get();
+  const edm4hep::ParticleIDCollection* reco_jettag_G_coll_ptr = m_recoJettagGHandle.get();
+  const edm4hep::ParticleIDCollection* reco_jettag_U_coll_ptr = m_recoJettagUHandle.get();
+  const edm4hep::ParticleIDCollection* reco_jettag_D_coll_ptr = m_recoJettagDHandle.get();
+  const edm4hep::ParticleIDCollection* reco_jettag_S_coll_ptr = m_recoJettagSHandle.get();
+  const edm4hep::ParticleIDCollection* reco_jettag_C_coll_ptr = m_recoJettagCHandle.get();
+  const edm4hep::ParticleIDCollection* reco_jettag_B_coll_ptr = m_recoJettagBHandle.get();
+  const edm4hep::ParticleIDCollection* reco_jettag_TAU_coll_ptr = m_recoJettagTauHandle.get();
+  const edm4hep::ParticleIDCollection* mc_jettag_coll_ptr = m_mcJettagHandle.get();
   // Create references to the collections
   const edm4hep::ReconstructedParticleCollection& jet_coll = *jet_coll_ptr;
   const edm4hep::ParticleIDCollection& reco_jettag_G_coll = *reco_jettag_G_coll_ptr;
@@ -120,18 +120,18 @@ StatusCode JetTagWriter::execute(const EventContext&) const {
     }
 
     // get the PID likelihoods
-    score_recojet_isG = jetTags_G[0].getLikelihood();
-    score_recojet_isU = jetTags_U[0].getLikelihood();
-    score_recojet_isD = jetTags_D[0].getLikelihood();
-    score_recojet_isS = jetTags_S[0].getLikelihood();
-    score_recojet_isC = jetTags_C[0].getLikelihood();
-    score_recojet_isB = jetTags_B[0].getLikelihood();
-    score_recojet_isTAU = jetTags_TAU[0].getLikelihood();
+    m_scoreRecojetIsG = jetTags_G[0].getLikelihood();
+    m_scoreRecoJetIsU = jetTags_U[0].getLikelihood();
+    m_scoreRecoJetIsD = jetTags_D[0].getLikelihood();
+    m_scoreRecoJetIsS = jetTags_S[0].getLikelihood();
+    m_scoreRecoJetIsC = jetTags_C[0].getLikelihood();
+    m_scoreRecoJetIsB = jetTags_B[0].getLikelihood();
+    m_scoreRecoJetIsTau = jetTags_TAU[0].getLikelihood();
 
     // check if no dummy value is left
-    if (score_recojet_isG == -9.0 || score_recojet_isU == -9.0 || score_recojet_isD == -9.0 ||
-        score_recojet_isS == -9.0 || score_recojet_isC == -9.0 || score_recojet_isB == -9.0 ||
-        score_recojet_isTAU == -9.0) {
+    if (m_scoreRecojetIsG == -9.0 || m_scoreRecoJetIsU == -9.0 || m_scoreRecoJetIsD == -9.0 ||
+        m_scoreRecoJetIsS == -9.0 || m_scoreRecoJetIsC == -9.0 || m_scoreRecoJetIsB == -9.0 ||
+        m_scoreRecoJetIsTau == -9.0) {
       error() << "Dummy value for probability scores still seems to be set!" << endmsg;
       continue;
     }
@@ -139,67 +139,67 @@ StatusCode JetTagWriter::execute(const EventContext&) const {
     // get MC jet flavor and set the corresponding bool to true
     int mc_flavor = mcJetTags[0].getPDG();
     if (mc_flavor == 21) {
-      recojet_isG = true;
+      m_recojetIsG = true;
     } else if (mc_flavor == 2) {
-      recojet_isU = true;
+      m_recoJetIsU = true;
     } else if (mc_flavor == 1) {
-      recojet_isD = true;
+      m_recoJetIsD = true;
     } else if (mc_flavor == 3) {
-      recojet_isS = true;
+      m_recoJetIsS = true;
     } else if (mc_flavor == 4) {
-      recojet_isC = true;
+      m_recoJetIsC = true;
     } else if (mc_flavor == 5) {
-      recojet_isB = true;
+      m_recoJetIsB = true;
     } else if (mc_flavor == 15) {
-      recojet_isTAU = true;
+      m_recoJetIsTAU = true;
     } else {
       error() << "MC jet flavor not found!" << endmsg;
       continue;
     }
 
     // fill the tree
-    t_jettag->Fill();
+    m_jettag->Fill();
   }
 
   return StatusCode::SUCCESS;
 }
 
 void JetTagWriter::initializeTree() {
-  t_jettag->Branch("recojet_isG", &recojet_isG, "recojet_isG/O");
-  t_jettag->Branch("score_recojet_isG", &score_recojet_isG, "score_recojet_isG/F");
-  t_jettag->Branch("recojet_isU", &recojet_isU, "recojet_isU/O");
-  t_jettag->Branch("score_recojet_isU", &score_recojet_isU, "score_recojet_isU/F");
-  t_jettag->Branch("recojet_isD", &recojet_isD, "recojet_isD/O");
-  t_jettag->Branch("score_recojet_isD", &score_recojet_isD, "score_recojet_isD/F");
-  t_jettag->Branch("recojet_isS", &recojet_isS, "recojet_isS/O");
-  t_jettag->Branch("score_recojet_isS", &score_recojet_isS, "score_recojet_isS/F");
-  t_jettag->Branch("recojet_isC", &recojet_isC, "recojet_isC/O");
-  t_jettag->Branch("score_recojet_isC", &score_recojet_isC, "score_recojet_isC/F");
-  t_jettag->Branch("recojet_isB", &recojet_isB, "recojet_isB/O");
-  t_jettag->Branch("score_recojet_isB", &score_recojet_isB, "score_recojet_isB/F");
-  t_jettag->Branch("recojet_isTAU", &recojet_isTAU, "recojet_isTAU/O");
-  t_jettag->Branch("score_recojet_isTAU", &score_recojet_isTAU, "score_recojet_isTAU/F");
+  m_jettag->Branch("recojet_isG", &m_recojetIsG, "recojet_isG/O");
+  m_jettag->Branch("score_recojet_isG", &m_scoreRecojetIsG, "score_recojet_isG/F");
+  m_jettag->Branch("m_recoJetIsU", &m_recoJetIsU, "m_recoJetIsU/O");
+  m_jettag->Branch("m_scoreRecoJetIsU", &m_scoreRecoJetIsU, "m_scoreRecoJetIsU/F");
+  m_jettag->Branch("m_recoJetIsD", &m_recoJetIsD, "m_recoJetIsD/O");
+  m_jettag->Branch("m_scoreRecoJetIsD", &m_scoreRecoJetIsD, "m_scoreRecoJetIsD/F");
+  m_jettag->Branch("m_recoJetIsS", &m_recoJetIsS, "m_recoJetIsS/O");
+  m_jettag->Branch("m_scoreRecoJetIsS", &m_scoreRecoJetIsS, "m_scoreRecoJetIsS/F");
+  m_jettag->Branch("m_recoJetIsC", &m_recoJetIsC, "m_recoJetIsC/O");
+  m_jettag->Branch("m_scoreRecoJetIsC", &m_scoreRecoJetIsC, "m_scoreRecoJetIsC/F");
+  m_jettag->Branch("m_recoJetIsB", &m_recoJetIsB, "m_recoJetIsB/O");
+  m_jettag->Branch("m_scoreRecoJetIsB", &m_scoreRecoJetIsB, "m_scoreRecoJetIsB/F");
+  m_jettag->Branch("m_recoJetIsTAU", &m_recoJetIsTAU, "m_recoJetIsTAU/O");
+  m_jettag->Branch("m_scoreRecoJetIsTAU", &m_scoreRecoJetIsTau, "m_scoreRecoJetIsTAU/F");
 
   return;
 }
 
 void JetTagWriter::cleanTree() const {
-  recojet_isG = false;
-  recojet_isU = false;
-  recojet_isD = false;
-  recojet_isS = false;
-  recojet_isC = false;
-  recojet_isB = false;
-  recojet_isTAU = false;
+  m_recojetIsG = false;
+  m_recoJetIsU = false;
+  m_recoJetIsD = false;
+  m_recoJetIsS = false;
+  m_recoJetIsC = false;
+  m_recoJetIsB = false;
+  m_recoJetIsTAU = false;
 
   float dummy_score = -9.0;
-  score_recojet_isTAU = dummy_score;
-  score_recojet_isG = dummy_score;
-  score_recojet_isU = dummy_score;
-  score_recojet_isD = dummy_score;
-  score_recojet_isS = dummy_score;
-  score_recojet_isC = dummy_score;
-  score_recojet_isB = dummy_score;
+  m_scoreRecoJetIsTau = dummy_score;
+  m_scoreRecojetIsG = dummy_score;
+  m_scoreRecoJetIsU = dummy_score;
+  m_scoreRecoJetIsD = dummy_score;
+  m_scoreRecoJetIsS = dummy_score;
+  m_scoreRecoJetIsC = dummy_score;
+  m_scoreRecoJetIsB = dummy_score;
 
   return;
 }

--- a/k4MLJetTagger/src/components/JetTagWriter.h
+++ b/k4MLJetTagger/src/components/JetTagWriter.h
@@ -22,14 +22,10 @@
 #include "Gaudi/Algorithm.h"
 #include "GaudiKernel/ITHistSvc.h"
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
 
 #include <edm4hep/EventHeaderCollection.h>
 #include <edm4hep/ReconstructedParticleCollection.h>
 #include <edm4hep/VertexCollection.h>
-
-#include "TGraph.h"
-#include "TH1F.h"
 
 #include <edm4hep/ParticleIDCollection.h>
 #include <edm4hep/utils/ParticleIDUtils.h>

--- a/k4MLJetTagger/src/components/JetTagWriter.h
+++ b/k4MLJetTagger/src/components/JetTagWriter.h
@@ -51,17 +51,21 @@ public:
   /// Destructor.
   ~JetTagWriter(){};
   /// Initialize.
-  virtual StatusCode initialize();
+  StatusCode initialize() override;
+  /// Execute function.
+  StatusCode execute(const EventContext&) const override;
+  /// Finalize.
+  StatusCode finalize() override;
+
+private:
   /// Initialize tree.
   void initializeTree();
   /// Clean tree.
   void cleanTree() const;
-  /// Execute function.
-  virtual StatusCode execute(const EventContext&) const;
-  /// Finalize.
-  virtual StatusCode finalize();
 
-private:
+  // Mark this algorithm as non-thread safe
+  bool isReEntrant() const final { return false; }
+
   mutable DataHandle<edm4hep::EventHeaderCollection> ev_handle{"EventHeader", Gaudi::DataHandle::Reader, this};
   mutable DataHandle<edm4hep::ReconstructedParticleCollection> jets_handle{"RefinedVertexJets",
                                                                            Gaudi::DataHandle::Reader, this};

--- a/k4MLJetTagger/src/components/JetTagWriter.h
+++ b/k4MLJetTagger/src/components/JetTagWriter.h
@@ -66,45 +66,46 @@ private:
   // Mark this algorithm as non-thread safe
   bool isReEntrant() const final { return false; }
 
-  mutable DataHandle<edm4hep::EventHeaderCollection> ev_handle{"EventHeader", Gaudi::DataHandle::Reader, this};
-  mutable DataHandle<edm4hep::ReconstructedParticleCollection> jets_handle{"RefinedVertexJets",
-                                                                           Gaudi::DataHandle::Reader, this};
-  mutable DataHandle<edm4hep::ParticleIDCollection> reco_jettag_G_handle{"RefinedJetTag_G", Gaudi::DataHandle::Reader,
+  mutable DataHandle<edm4hep::EventHeaderCollection> m_eventHeaderHandle{"EventHeader", Gaudi::DataHandle::Reader,
                                                                          this};
-  mutable DataHandle<edm4hep::ParticleIDCollection> reco_jettag_U_handle{"RefinedJetTag_U", Gaudi::DataHandle::Reader,
-                                                                         this};
-  mutable DataHandle<edm4hep::ParticleIDCollection> reco_jettag_D_handle{"RefinedJetTag_D", Gaudi::DataHandle::Reader,
-                                                                         this};
-  mutable DataHandle<edm4hep::ParticleIDCollection> reco_jettag_S_handle{"RefinedJetTag_S", Gaudi::DataHandle::Reader,
-                                                                         this};
-  mutable DataHandle<edm4hep::ParticleIDCollection> reco_jettag_C_handle{"RefinedJetTag_C", Gaudi::DataHandle::Reader,
-                                                                         this};
-  mutable DataHandle<edm4hep::ParticleIDCollection> reco_jettag_B_handle{"RefinedJetTag_B", Gaudi::DataHandle::Reader,
-                                                                         this};
-  mutable DataHandle<edm4hep::ParticleIDCollection> reco_jettag_TAU_handle{"RefinedJetTag_TAU",
-                                                                           Gaudi::DataHandle::Reader, this};
-  mutable DataHandle<edm4hep::ParticleIDCollection> mc_jettag_handle{"MCJetTag", Gaudi::DataHandle::Reader, this};
+  mutable DataHandle<edm4hep::ReconstructedParticleCollection> m_jetsHandle{"RefinedVertexJets",
+                                                                            Gaudi::DataHandle::Reader, this};
+  mutable DataHandle<edm4hep::ParticleIDCollection> m_recoJettagGHandle{"RefinedJetTag_G", Gaudi::DataHandle::Reader,
+                                                                        this};
+  mutable DataHandle<edm4hep::ParticleIDCollection> m_recoJettagUHandle{"RefinedJetTag_U", Gaudi::DataHandle::Reader,
+                                                                        this};
+  mutable DataHandle<edm4hep::ParticleIDCollection> m_recoJettagDHandle{"RefinedJetTag_D", Gaudi::DataHandle::Reader,
+                                                                        this};
+  mutable DataHandle<edm4hep::ParticleIDCollection> m_recoJettagSHandle{"RefinedJetTag_S", Gaudi::DataHandle::Reader,
+                                                                        this};
+  mutable DataHandle<edm4hep::ParticleIDCollection> m_recoJettagCHandle{"RefinedJetTag_C", Gaudi::DataHandle::Reader,
+                                                                        this};
+  mutable DataHandle<edm4hep::ParticleIDCollection> m_recoJettagBHandle{"RefinedJetTag_B", Gaudi::DataHandle::Reader,
+                                                                        this};
+  mutable DataHandle<edm4hep::ParticleIDCollection> m_recoJettagTauHandle{"RefinedJetTag_TAU",
+                                                                          Gaudi::DataHandle::Reader, this};
+  mutable DataHandle<edm4hep::ParticleIDCollection> m_mcJettagHandle{"MCJetTag", Gaudi::DataHandle::Reader, this};
 
   SmartIF<ITHistSvc> m_ths; ///< THistogram service
 
-  mutable TTree* t_jettag{nullptr};
+  mutable TTree* m_jettag{nullptr};
 
-  mutable bool recojet_isG;
-  mutable float score_recojet_isG;
-  mutable bool recojet_isU;
-  mutable float score_recojet_isU;
-  mutable bool recojet_isD;
-  mutable float score_recojet_isD;
-  mutable bool recojet_isS;
-  mutable float score_recojet_isS;
-  mutable bool recojet_isC;
-  mutable float score_recojet_isC;
-  mutable bool recojet_isB;
-  mutable float score_recojet_isB;
-  mutable bool recojet_isTAU;
-  mutable float score_recojet_isTAU;
+  mutable bool m_recojetIsG;
+  mutable float m_scoreRecojetIsG;
+  mutable bool m_recoJetIsU;
+  mutable float m_scoreRecoJetIsU;
+  mutable bool m_recoJetIsD;
+  mutable float m_scoreRecoJetIsD;
+  mutable bool m_recoJetIsS;
+  mutable float m_scoreRecoJetIsS;
+  mutable bool m_recoJetIsC;
+  mutable float m_scoreRecoJetIsC;
+  mutable bool m_recoJetIsB;
+  mutable float m_scoreRecoJetIsB;
+  mutable bool m_recoJetIsTAU;
+  mutable float m_scoreRecoJetIsTau;
 
-  mutable std::int32_t evNum;
+  mutable std::int32_t m_evNum;
 };
 
 #endif // JETTAGWRITER_H

--- a/k4MLJetTagger/src/components/JetTagger.cpp
+++ b/k4MLJetTagger/src/components/JetTagger.cpp
@@ -106,7 +106,7 @@ struct JetTagger : k4FWCore::Transformer<std::vector<edm4hep::ParticleIDCollecti
   // initialize
   StatusCode initialize() override {
     // Load the JSON configuration file and retrieve the flavor names
-    json_config = loadJsonFile(json_path);
+    auto json_config = loadJsonFile(json_path);
     flavorNames = json_config["output_names"]; // e.g. "recojet_isX" with X being the jet flavor (G, U, S, C, B, D, TAU)
 
     // check if flavorNames matches order and size of the output collections
@@ -145,7 +145,6 @@ struct JetTagger : k4FWCore::Transformer<std::vector<edm4hep::ParticleIDCollecti
 
   // properties
 private:
-  nlohmann::json json_config;
   std::vector<std::string> flavorNames; // e.g. "recojet_isX" with X being the jet flavor (G, U, S, C, B, D, TAU)
   std::vector<int> PDGflavors;
   rv::RVec<std::string> vars; // e.g. pfcand_isEl, ... input names that onnx model expects

--- a/k4MLJetTagger/src/components/JetTagger.cpp
+++ b/k4MLJetTagger/src/components/JetTagger.cpp
@@ -25,7 +25,6 @@
 #include <edm4hep/ReconstructedParticleCollection.h>
 #include <edm4hep/VertexCollection.h>
 
-#include <fstream>
 #include <nlohmann/json.hpp> // Include a JSON parsing library
 
 #include "Helpers.h"

--- a/k4MLJetTagger/src/components/ONNXRuntime.cpp
+++ b/k4MLJetTagger/src/components/ONNXRuntime.cpp
@@ -21,9 +21,6 @@
 #include "onnxruntime_cxx_api.h"
 // #include "experimental_onnxruntime_cxx_api.h"
 
-#include <fstream>
-#include <iostream>
-
 #include <algorithm>
 #include <numeric>
 

--- a/k4MLJetTagger/src/components/ONNXRuntime.cpp
+++ b/k4MLJetTagger/src/components/ONNXRuntime.cpp
@@ -25,44 +25,44 @@
 #include <numeric>
 
 ONNXRuntime::ONNXRuntime(const std::string& model_path, const std::vector<std::string>& input_names)
-    : env_(new Ort::Env(OrtLoggingLevel::ORT_LOGGING_LEVEL_WARNING, "onnx_runtime")), allocator(),
-      input_names_(input_names) {
+    : m_env(new Ort::Env(OrtLoggingLevel::ORT_LOGGING_LEVEL_WARNING, "onnx_runtime")), m_allocator(),
+      m_inputNames(input_names) {
   if (model_path.empty())
     throw std::runtime_error("Path to ONNX model cannot be empty!");
   Ort::SessionOptions options;
   options.SetIntraOpNumThreads(1);
   std::string model{model_path}; // fixes a poor Ort experimental API
-  session_ = std::make_unique<Ort::Session>(*env_, model.c_str(), options);
+  m_session = std::make_unique<Ort::Session>(*m_env, model.c_str(), options);
 
   // Get input names and shapes
-  input_node_strings_.clear();
-  input_node_dims_.clear();
+  m_inputNodeStrings.clear();
+  m_inputNodeDims.clear();
 
-  for (size_t i = 0; i < session_->GetInputCount(); ++i) {
+  for (size_t i = 0; i < m_session->GetInputCount(); ++i) {
     // get input names
     const auto input_name =
-        session_->GetInputNameAllocated(i, allocator).release(); // release the ownership of the pointer
-    input_node_strings_.emplace_back(input_name);
+        m_session->GetInputNameAllocated(i, m_allocator).release(); // release the ownership of the pointer
+    m_inputNodeStrings.emplace_back(input_name);
 
     // get input shapes
-    const auto nodeInfo = session_->GetInputTypeInfo(i);
-    input_node_dims_[input_name] = nodeInfo.GetTensorTypeAndShapeInfo().GetShape();
+    const auto nodeInfo = m_session->GetInputTypeInfo(i);
+    m_inputNodeDims[input_name] = nodeInfo.GetTensorTypeAndShapeInfo().GetShape();
   }
 
   // Get output names and shapes
-  output_node_strings_.clear();
-  output_node_dims_.clear();
-  for (size_t i = 0; i < session_->GetOutputCount(); ++i) {
+  m_outputNodeStrings.clear();
+  m_outputNodeDims.clear();
+  for (size_t i = 0; i < m_session->GetOutputCount(); ++i) {
     // Get output names
-    const auto output_name = session_->GetOutputNameAllocated(i, allocator).release();
-    output_node_strings_.emplace_back(output_name);
+    const auto output_name = m_session->GetOutputNameAllocated(i, m_allocator).release();
+    m_outputNodeStrings.emplace_back(output_name);
 
     // get output shapes
-    const auto nodeInfo = session_->GetOutputTypeInfo(i);
-    output_node_dims_[output_name] = nodeInfo.GetTensorTypeAndShapeInfo().GetShape();
+    const auto nodeInfo = m_session->GetOutputTypeInfo(i);
+    m_outputNodeDims[output_name] = nodeInfo.GetTensorTypeAndShapeInfo().GetShape();
 
     // the 0th dim depends on the batch size
-    output_node_dims_[output_name].at(0) = -1;
+    m_outputNodeDims[output_name].at(0) = -1;
   }
 }
 
@@ -72,12 +72,12 @@ template <typename T>
 ONNXRuntime::Tensor<T> ONNXRuntime::run(Tensor<T>& input, const Tensor<long>& input_shapes,
                                         unsigned long long batch_size) const {
   std::vector<Ort::Value> tensors_in;
-  for (const auto& name : input_node_strings_) {
+  for (const auto& name : m_inputNodeStrings) {
     auto input_pos = variablePos(name);
     auto value = input.begin() + input_pos;
     std::vector<int64_t> input_dims;
     if (input_shapes.empty()) {
-      input_dims = input_node_dims_.at(name);
+      input_dims = m_inputNodeDims.at(name);
       input_dims[0] = batch_size;
     } else {
       input_dims = input_shapes[input_pos];
@@ -103,18 +103,18 @@ ONNXRuntime::Tensor<T> ONNXRuntime::run(Tensor<T>& input, const Tensor<long>& in
 
   // convert to char*
   std::vector<const char*> input_node_names;
-  for (const auto& name_i : input_node_strings_) {
+  for (const auto& name_i : m_inputNodeStrings) {
     input_node_names.push_back(name_i.c_str());
   }
 
   std::vector<const char*> output_node_names;
-  for (const auto& name_j : output_node_strings_) {
+  for (const auto& name_j : m_outputNodeStrings) {
     output_node_names.push_back(name_j.c_str());
   }
 
   // run the inference
-  auto output_tensors = session_->Run(Ort::RunOptions{nullptr}, input_node_names.data(), tensors_in.data(),
-                                      tensors_in.size(), output_node_names.data(), output_node_names.size());
+  auto output_tensors = m_session->Run(Ort::RunOptions{nullptr}, input_node_names.data(), tensors_in.data(),
+                                       tensors_in.size(), output_node_names.data(), output_node_names.size());
   // convert output tensor to values
   Tensor<T> outputs;
   size_t i = 0;
@@ -129,18 +129,18 @@ ONNXRuntime::Tensor<T> ONNXRuntime::run(Tensor<T>& input, const Tensor<long>& in
     outputs.emplace_back(floatarr, floatarr + length);
     ++i;
   }
-  if (outputs.size() != session_->GetOutputCount())
+  if (outputs.size() != m_session->GetOutputCount())
     throw std::runtime_error("Number of outputs differ from the expected one: got " + std::to_string(outputs.size()) +
-                             ", expected " + std::to_string(session_->GetOutputCount()));
+                             ", expected " + std::to_string(m_session->GetOutputCount()));
 
   return outputs;
 }
 
 size_t ONNXRuntime::variablePos(const std::string& name) const {
-  auto iter = std::find(input_names_.begin(), input_names_.end(), name);
-  if (iter == input_names_.end())
+  auto iter = std::find(m_inputNames.begin(), m_inputNames.end(), name);
+  if (iter == m_inputNames.end())
     throw std::runtime_error("Input variable '" + name + " is not provided");
-  return iter - input_names_.begin();
+  return iter - m_inputNames.begin();
 }
 
 template ONNXRuntime::Tensor<float> ONNXRuntime::run(Tensor<float>&, const Tensor<long>&, unsigned long long) const;

--- a/k4MLJetTagger/src/components/ONNXRuntime.h
+++ b/k4MLJetTagger/src/components/ONNXRuntime.h
@@ -76,7 +76,7 @@ public:
    *
    * @return A constant reference to the vector of input names.
    */
-  const std::vector<std::string>& inputNames() const { return input_names_; }
+  const std::vector<std::string>& inputNames() const { return m_inputNames; }
 
   /**
    * @brief Runs inference on the provided input tensor and returns the output tensor.
@@ -100,15 +100,15 @@ private:
    */
   size_t variablePos(const std::string& var_name) const;
 
-  std::unique_ptr<Ort::Env> env_;             ///< Pointer to the ONNX Runtime environment object.
-  std::unique_ptr<Ort::Session> session_;     ///< Pointer to the ONNX Runtime session object.
-  Ort::AllocatorWithDefaultOptions allocator; ///< Allocator for ONNX Runtime tensors.
+  std::unique_ptr<Ort::Env> m_env;              ///< Pointer to the ONNX Runtime environment object.
+  std::unique_ptr<Ort::Session> m_session;      ///< Pointer to the ONNX Runtime session object.
+  Ort::AllocatorWithDefaultOptions m_allocator; ///< Allocator for ONNX Runtime tensors.
 
-  std::vector<std::string> input_node_strings_;                  ///< List of input node names.
-  std::vector<std::string> output_node_strings_;                 ///< List of output node names.
-  std::vector<std::string> input_names_;                         ///< List of model input names.
-  std::map<std::string, std::vector<int64_t>> input_node_dims_;  ///< Dimensions of input nodes.
-  std::map<std::string, std::vector<int64_t>> output_node_dims_; ///< Dimensions of output nodes.
+  std::vector<std::string> m_inputNodeStrings;                  ///< List of input node names.
+  std::vector<std::string> m_outputNodeStrings;                 ///< List of output node names.
+  std::vector<std::string> m_inputNames;                        ///< List of model input names.
+  std::map<std::string, std::vector<int64_t>> m_inputNodeDims;  ///< Dimensions of input nodes.
+  std::map<std::string, std::vector<int64_t>> m_outputNodeDims; ///< Dimensions of output nodes.
 };
 
 #endif

--- a/k4MLJetTagger/src/components/WeaverInterface.h
+++ b/k4MLJetTagger/src/components/WeaverInterface.h
@@ -145,12 +145,12 @@ private:
    */
   size_t variablePos(const std::string& var_name) const;
 
-  std::unique_ptr<ONNXRuntime> onnx_;                               ///< Pointer to the ONNX runtime object.
-  std::vector<std::string> variables_names_;                        ///< List of input variable names.
-  ONNXRuntime::Tensor<long> input_shapes_;                          ///< Tensor describing input shapes.
-  std::vector<unsigned int> input_sizes_;                           ///< List of input sizes for each dimension.
-  std::unordered_map<std::string, PreprocessParams> prep_info_map_; ///< Map of preprocessing parameters.
-  ONNXRuntime::Tensor<float> data_;                                 ///< Tensor for input data.
+  std::unique_ptr<ONNXRuntime> m_onnx;                             ///< Pointer to the ONNX runtime object.
+  std::vector<std::string> m_variablesNames;                       ///< List of input variable names.
+  ONNXRuntime::Tensor<long> m_inputShapes;                         ///< Tensor describing input shapes.
+  std::vector<unsigned int> m_inputSizes;                          ///< List of input sizes for each dimension.
+  std::unordered_map<std::string, PreprocessParams> m_prepInfoMap; ///< Map of preprocessing parameters.
+  ONNXRuntime::Tensor<float> m_data;                               ///< Tensor for input data.
 };
 
 #endif


### PR DESCRIPTION
BEGINRELEASENOTES
- Cleanup a few (unused) includes
- Make sure that all member variables follow the convention of being `m_` prefixed and then using camelCase

ENDRELEASENOTES
